### PR TITLE
Drastically improve performance by not registering for WoW events that nothing is listening for.

### DIFF
--- a/Helpers.lua
+++ b/Helpers.lua
@@ -503,6 +503,7 @@ local function _clearCodes()
 		if codeToEventList_nsList_kwargTypes_code then
 			for event, arg in pairs(codeToEventList_nsList_kwargTypes_code) do
 				eventData[event][fs] = arg
+				DogTag.eventUsed(event)
 			end
 		end
 		fsNeedQuickUpdate[fs] = true

--- a/LibDogTag-3.0.lua
+++ b/LibDogTag-3.0.lua
@@ -430,6 +430,7 @@ function DogTag:AddFontString(fs, frame, code, nsList, kwargs)
 	if codeToEventList_nsList_kwargTypes_code then
 		for event, arg in pairs(codeToEventList_nsList_kwargTypes_code) do
 			eventData[event][fs] = arg
+			DogTag.eventUsed(event)
 		end
 	end
 	


### PR DESCRIPTION
Drastically improve performance by not registering for WoW events that nothing is listening for. CLE/CLEU are obviously the biggest offenders, but everything else adds up too.

This change also enables [similar changes in LibDogTag-Unit that I PR'd here](https://github.com/parnic/LibDogTag-Unit-3.0/pull/3) which are dependent on this change (because they're dependent on the new `EventRequested` event).

Tested with both TMW and PitBull4.

CPU Before and after (after includes the LDT-Unit change), each taken over the span of a kill of the Shadowlands world boss. Pay no mind to Handynotes doing Handynotes things:

| Before | After |
| ----------- | ----------- |
| ![image](https://user-images.githubusercontent.com/5017521/111894726-5bb63900-89ca-11eb-8754-4ccdd35c8fe2.png) | ![image](https://user-images.githubusercontent.com/5017521/111894758-a6d04c00-89ca-11eb-86ac-5d287863d659.png) |