### PR TITLE
Properly reconstitute UTF8 strings 

### DIFF
--- a/Parser.lua
+++ b/Parser.lua
@@ -1188,9 +1188,23 @@ local function getLiteralString(str, doubleQuote)
 	local t = newList()
 	t[#t+1] = quote_byte
 	local i = 1
+	local multibytes = 0
 	while i <= #data do
 		local v = data[i]
-		if v == quote_byte then
+
+		-- https://stackoverflow.com/a/44776334/2465631
+		if v >= 240 then     -- 0b11110000
+			multibytes = 4
+		elseif v >= 225 then -- 0b11100000
+			multibytes = 3
+		elseif v >= 192 then -- 0b11000000
+			multibytes = 2
+		end
+
+		if multibytes > 0 then
+			t[#t+1] = v
+			multibytes = multibytes - 1
+		elseif v == quote_byte then
 			t[#t+1] = backslash_byte
 			t[#t+1] = quote_byte
 		elseif v == newline_byte then


### PR DESCRIPTION
Fixes https://github.com/ascott18/TellMeWhen/issues/1910 - properly reconstitute UTF8 strings rather than arbitrarily turning all bytes above 127 into escape sequences.

Turns this (the string gets mangled after passing through the CleanCode function and therefore just gets ignored by Blizzard textboxes as it fails to be well-formed UTF8):
![image](https://user-images.githubusercontent.com/5017521/130311693-45ff6c75-7083-4d25-8e85-83ac60685c17.png)

into this:
![image](https://user-images.githubusercontent.com/5017521/130311681-501c1ffd-6823-4cdb-bbd9-d6b46bd9bd4d.png)
