### PR TITLE
Fix syntax coloring for 9.0-based clients.

### DIFF
--- a/Help.lua
+++ b/Help.lua
@@ -846,7 +846,13 @@ function DogTag:OpenHelp()
 			local x = text:sub(3, -3)
 			x = "[" .. x .. "]"
 			x = DogTag:ColorizeCode(x)
-			local y = x:match("^|cff%x%x%x%x%x%x%[|r(|cff%x%x%x%x%x%x.*)|cff%x%x%x%x%x%x%]|r$") .. "|r"
+			-- Find the first opening bracket in the colored string,
+			-- which is the one we just prepended to `x`.
+			local first = string.find(x, "|cff%x%x%x%x%x%x%[")
+			-- Find the last closing bracket in the colored string,
+			-- which is the one we just appended to `x`.
+			local last = string.find(x, "%]|r[^%]]*$")
+			local y = x:sub(first, last + 2) -- +2 for length of `|r`
 			return y
 		end
 		return DogTag:ColorizeCode(text:sub(2, -2))

--- a/Help.lua
+++ b/Help.lua
@@ -846,7 +846,7 @@ function DogTag:OpenHelp()
 			local x = text:sub(3, -3)
 			x = "[" .. x .. "]"
 			x = DogTag:ColorizeCode(x)
-			local y = x:match("^|cff%x%x%x%x%x%x%[(|cff%x%x%x%x%x%x.*)|cff%x%x%x%x%x%x%]|r$") .. "|r"
+			local y = x:match("^|cff%x%x%x%x%x%x%[|r(|cff%x%x%x%x%x%x.*)|cff%x%x%x%x%x%x%]|r$") .. "|r"
 			return y
 		end
 		return DogTag:ColorizeCode(text:sub(2, -2))

--- a/Help.lua
+++ b/Help.lua
@@ -848,11 +848,11 @@ function DogTag:OpenHelp()
 			x = DogTag:ColorizeCode(x)
 			-- Find the first opening bracket in the colored string,
 			-- which is the one we just prepended to `x`.
-			local first = string.find(x, "|cff%x%x%x%x%x%x%[")
+			local first = string.find(x, "|cff%x%x%x%x%x%x%[") + 11
 			-- Find the last closing bracket in the colored string,
 			-- which is the one we just appended to `x`.
-			local last = string.find(x, "%]|r[^%]]*$")
-			local y = x:sub(first, last + 2) -- +2 for length of `|r`
+			local last = string.find(x, "|cff%x%x%x%x%x%x%]|r[^%]]*$") - 1
+			local y = x:sub(first, last)
 			return y
 		end
 		return DogTag:ColorizeCode(text:sub(2, -2))

--- a/Parser.lua
+++ b/Parser.lua
@@ -1795,8 +1795,6 @@ function DogTag:ColorizeCode(code)
 	end
 	tokens = del(tokens)
 	local s = table.concat(t)
-	-- s = s:gsub("|c%x%x%x%x%x%x%x%x(|[cr])", "%1")
-	-- s = s:gsub("|r|r$", "|r")
 	if s == "|r" then
 		s = ""
 	end

--- a/Parser.lua
+++ b/Parser.lua
@@ -1675,6 +1675,7 @@ function DogTag:ColorizeCode(code)
 			if v == inString and not lastStringBackslash then
 				inString = false
 				t[#t+1] = string_char(v)
+				t[#t+1] = "|r"
 			else
 				t[#t+1] = string_char(v)
 			end
@@ -1682,11 +1683,13 @@ function DogTag:ColorizeCode(code)
 			t[#t+1] = "|cff"
 			t[#t+1] = colors.grouping
 			t[#t+1] = "["
+			t[#t+1] = "|r"
 			inCode = inCode + 1
 		elseif v == close_bracket_byte then
 			t[#t+1] = "|cff"
 			t[#t+1] = colors.grouping
 			t[#t+1] = "]"
+			t[#t+1] = "|r"
 			inCode = inCode - 1
 			if inCode == 0 then
 				t[#t+1] = "|cff"
@@ -1698,14 +1701,17 @@ function DogTag:ColorizeCode(code)
 			t[#t+1] = "|cff"
 			t[#t+1] = colors.grouping
 			t[#t+1] = "("
+			t[#t+1] = "|r"
 		elseif v == close_parenthesis_byte then
 			t[#t+1] = "|cff"
 			t[#t+1] = colors.grouping
 			t[#t+1] = ")"
+			t[#t+1] = "|r"
 		elseif v == comma_byte then
 			t[#t+1] = "|cff"
 			t[#t+1] = colors.grouping
 			t[#t+1] = ","
+			t[#t+1] = "|r"
 		elseif quotes[v] then
 			t[#t+1] = "|cff"
 			t[#t+1] = colors.literal
@@ -1725,6 +1731,7 @@ function DogTag:ColorizeCode(code)
 				t[#t+1] = "|cff"
 				t[#t+1] = colors.operator
 				t[#t+1] = isReserved
+				t[#t+1] = "|r"
 				i = i + #isReserved - 1
 			else
 				local j = i
@@ -1746,6 +1753,7 @@ function DogTag:ColorizeCode(code)
 					for q = i, j do
 						t[#t+1] = string_char(tokens[q])
 					end
+					t[#t+1] = "|r"
 					i = j
 				else
 					j = i
@@ -1767,6 +1775,7 @@ function DogTag:ColorizeCode(code)
 						for q = i, j do
 							t[#t+1] = string_char(tokens[q])
 						end
+						t[#t+1] = "|r"
 						i = j
 					else
 						t[#t+1] = string_char(v)
@@ -1782,6 +1791,7 @@ function DogTag:ColorizeCode(code)
 	tokens = del(tokens)
 	local s = table.concat(t)
 	s = s:gsub("|c%x%x%x%x%x%x%x%x(|[cr])", "%1")
+	s = s:gsub("|r|r$", "|r")
 	if s == "|r" then
 		s = ""
 	end

--- a/Parser.lua
+++ b/Parser.lua
@@ -1691,10 +1691,6 @@ function DogTag:ColorizeCode(code)
 			t[#t+1] = "]"
 			t[#t+1] = "|r"
 			inCode = inCode - 1
-			if inCode == 0 then
-				t[#t+1] = "|cff"
-				t[#t+1] = colors.literal
-			end
 		elseif inCode <= 0 then
 			t[#t+1] = string_char(v)
 		elseif v == open_parenthesis_byte then
@@ -1790,8 +1786,6 @@ function DogTag:ColorizeCode(code)
 	t[#t+1] = "|r"
 	tokens = del(tokens)
 	local s = table.concat(t)
-	s = s:gsub("|c%x%x%x%x%x%x%x%x(|[cr])", "%1")
-	s = s:gsub("|r|r$", "|r")
 	if s == "|r" then
 		s = ""
 	end

--- a/Parser.lua
+++ b/Parser.lua
@@ -1680,6 +1680,9 @@ function DogTag:ColorizeCode(code)
 				t[#t+1] = string_char(v)
 			end
 		elseif v == open_bracket_byte then
+			if inCode == 0 then
+				t[#t+1] = "|r"
+			end
 			t[#t+1] = "|cff"
 			t[#t+1] = colors.grouping
 			t[#t+1] = "["
@@ -1691,6 +1694,10 @@ function DogTag:ColorizeCode(code)
 			t[#t+1] = "]"
 			t[#t+1] = "|r"
 			inCode = inCode - 1
+			if inCode == 0 then
+				t[#t+1] = "|cff"
+				t[#t+1] = colors.literal
+			end
 		elseif inCode <= 0 then
 			t[#t+1] = string_char(v)
 		elseif v == open_parenthesis_byte then
@@ -1783,9 +1790,13 @@ function DogTag:ColorizeCode(code)
 			lastChar = tokens[i]
 		end
 	end
-	t[#t+1] = "|r"
+	if inCode == 0 then
+		t[#t+1] = "|r"
+	end
 	tokens = del(tokens)
 	local s = table.concat(t)
+	-- s = s:gsub("|c%x%x%x%x%x%x%x%x(|[cr])", "%1")
+	-- s = s:gsub("|r|r$", "|r")
 	if s == "|r" then
 		s = ""
 	end


### PR DESCRIPTION

| Before | After |
| ----------- | ----------- |
| ![image](https://user-images.githubusercontent.com/5017521/130313392-4f39cd88-2995-4cbb-be96-c5daf836e181.png)  | ![image](https://user-images.githubusercontent.com/5017521/130313407-140f3841-662a-4e24-ab28-12ae17579fe8.png) |

Caused by this change in WoW 9.0:

> The `|r` escape sequence now pops nested `|c` color sequences in-order, instead of resetting the text to the default color.

Unfortunately, it seems this color sequence stack is very small. Seemed to only be around 8 colors max before it gives up and gets stuck on a color permanently despite any additional `|c`olor sequences.