### PR TITLE
Fix shortNumberOptions for Asian localizations

### DIFF
--- a/Categories/TextManip.lua
+++ b/Categories/TextManip.lua
@@ -31,7 +31,13 @@ local veryShortNumberOptions = {
 	}
 }
 
-if CreateAbbreviateConfig then
+local locale = GetLocale and GetLocale()
+if locale == "zhCN" or locale == "zhTW" or locale == "koKR" then
+	-- Asian localizations only use 万 and 亿 as abbreviations, so do not apply
+	-- custom breakpoint options which are designed for western k/m/b notation.
+	shortNumberOptions = nil
+	veryShortNumberOptions = nil
+elseif CreateAbbreviateConfig then
 	-- High perf API
 	shortNumberOptions = { config = CreateAbbreviateConfig(shortNumberOptions.breakpointData) }
 	veryShortNumberOptions = { config = CreateAbbreviateConfig(veryShortNumberOptions.breakpointData) }


### PR DESCRIPTION
This pull request updates the logic for number abbreviation configuration in `TextManip.lua` to better support Asian locales. Specifically, it ensures that custom abbreviation breakpoints are not applied for Chinese and Korean localizations, which use different notation for large numbers. For example, 1,000 would show as "1万" instead of the correct "1k" style (since Asian locales only use 万 at 10,000 and 亿 at 100,000,000).

Localization improvements:

* Added a locale check for `zhCN`, `zhTW`, and `koKR` so that custom abbreviation options (`shortNumberOptions`, `veryShortNumberOptions`) are disabled for these Asian locales, aligning with their use of 万 and 亿 instead of western k/m/b notation. 